### PR TITLE
Add npm-based React/Tailwind sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ ChatGPT の簡易 Web UI サンプルです。
 `sample` には React を使ったシンプルなチャット画面があります。
 `data/sample.json` を読み込んでセッションとメッセージを表示します。
 CDN 経由で React を読み込むだけの軽量な構成です。
+
+## Tailwind + React 版
+プロジェクトルートには npm を使った `react-tailwind` サンプルがあります。 `public/sample.json` を読み込んで同様のチャット UI を表示します。Tailwind CSS を利用するので、下記の手順でセットアップしてください。
+
+```bash
+npm install
+npm run dev
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Tailwind Sample</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "react-sample",
+  "version": "1.0.0",
+  "description": "ChatGPT の簡易 Web UI サンプルです。",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.35",
+    "autoprefixer": "^10.4.19"
+  },
+  "type": "module"
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/sample.json
+++ b/public/sample.json
@@ -1,0 +1,90 @@
+{
+  "sessions": [
+    {
+      "id": 1,
+      "title": "最初の会話",
+      "created_at": "2025-07-10 10:00:00.000000",
+      "updated_at": "2025-07-10 10:05:00.000000"
+    },
+    {
+      "id": 2,
+      "title": "プロジェクト相談",
+      "created_at": "2025-07-10 11:00:00.000000",
+      "updated_at": "2025-07-10 11:12:00.000000"
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "session_id": 1,
+      "role": "user",
+      "content": "こんにちは。",
+      "timestamp": "2025-07-10 10:00:05.000000"
+    },
+    {
+      "id": 2,
+      "session_id": 1,
+      "role": "assistant",
+      "content": "こんにちは。今日は何をしましょうか？",
+      "timestamp": "2025-07-10 10:00:06.000000"
+    },
+    {
+      "id": 3,
+      "session_id": 1,
+      "role": "user",
+      "content": "自己紹介してください。",
+      "timestamp": "2025-07-10 10:01:00.000000"
+    },
+    {
+      "id": 4,
+      "session_id": 1,
+      "role": "assistant",
+      "content": "私はOpenAIが開発したAIアシスタントです。",
+      "timestamp": "2025-07-10 10:01:01.000000"
+    },
+    {
+      "id": 5,
+      "session_id": 2,
+      "role": "user",
+      "content": "ReactでチャットUIを作りたいんだけど",
+      "timestamp": "2025-07-10 11:00:00.000000"
+    },
+    {
+      "id": 6,
+      "session_id": 2,
+      "role": "assistant",
+      "content": "もちろん。どういった構成を考えていますか？",
+      "timestamp": "2025-07-10 11:00:02.000000"
+    },
+    {
+      "id": 7,
+      "session_id": 2,
+      "role": "user",
+      "content": "OpenAI APIと連携して、会話を保存したい",
+      "timestamp": "2025-07-10 11:10:00.000000"
+    },
+    {
+      "id": 8,
+      "session_id": 2,
+      "role": "assistant",
+      "content": "SQLiteでセッションとメッセージを管理する構成が良いでしょう。",
+      "timestamp": "2025-07-10 11:12:00.000000"
+    }
+  ],
+  "settings": [
+    {
+      "id": 1,
+      "session_id": 1,
+      "model": "gpt-3.5-turbo",
+      "temperature": 1.0,
+      "top_p": 1.0
+    },
+    {
+      "id": 2,
+      "session_id": 2,
+      "model": "gpt-4",
+      "temperature": 0.7,
+      "top_p": 1.0
+    }
+  ]
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react';
+
+export default function App() {
+  const [data, setData] = useState(null);
+  const [currentSession, setCurrentSession] = useState(null);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    fetch('/sample.json')
+      .then(res => res.json())
+      .then(json => {
+        setData(json);
+        if (json.sessions && json.sessions.length > 0) {
+          setCurrentSession(json.sessions[0].id);
+        }
+      });
+  }, []);
+
+  if (!data) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  const messages = data.messages.filter(m => m.session_id === currentSession);
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    const newMessage = {
+      id: data.messages.length + 1,
+      session_id: currentSession,
+      role: 'user',
+      content: input,
+      timestamp: new Date().toISOString(),
+    };
+    setData({ ...data, messages: [...data.messages, newMessage] });
+    setInput('');
+  };
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar sessions={data.sessions} current={currentSession} onSelect={setCurrentSession} />
+      <Chat messages={messages} input={input} onInput={setInput} onSend={handleSend} />
+    </div>
+  );
+}
+
+function Sidebar({ sessions, current, onSelect }) {
+  return (
+    <div className="w-48 bg-gray-800 overflow-y-auto p-2">
+      {sessions.map(s => (
+        <div
+          key={s.id}
+          className={`p-2 cursor-pointer rounded ${s.id === current ? 'bg-gray-600' : ''}`}
+          onClick={() => onSelect(s.id)}
+        >
+          {s.title}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Chat({ messages, input, onInput, onSend }) {
+  return (
+    <div className="flex flex-col flex-1">
+      <div className="flex-1 p-4 overflow-y-auto">
+        {messages.map(m => (
+          <div key={m.id} className={`mb-4 ${m.role === 'user' ? 'text-right' : ''}`}>
+            <div className="inline-block bg-gray-700 px-3 py-2 rounded">
+              {m.content}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex p-2 border-t border-gray-700">
+        <textarea
+          className="flex-1 resize-none mr-2 text-black"
+          value={input}
+          onChange={e => onInput(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-3 py-1 rounded" onClick={onSend}>
+          送信
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-900 text-white;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add root React/Tailwind project using Vite
- include Tailwind config and PostCSS setup
- implement chat UI that loads `public/sample.json`
- document how to start the new sample

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686f6f68f6548325aa4815121165f3e8